### PR TITLE
modify rake task to allow specification of a directory or file to specifially run, instead of the whole library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ tests with:
 ```
 $ bundle
 $ bundle exec rake
+$ bundle exec rake test <relative-path>  # to run a subset of tests
 ```
 
 Most tests should pass. (If a few tests fail, that's okay. Some of the tests are

--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,10 @@ require "rake/testtask"
 Rake::TestTask.new(:test) do |t|
   t.libs << "smells"
   t.libs << "support/ruby"
+  tests = ARGV[1] || "smells/**/*.rb"
   t.test_files = FileList[
     "support/ruby/helper.rb",
-    "smells/**/*.rb"
+    tests
   ]
 end
 


### PR DESCRIPTION
While working through refactoring tests, we want to be able to run just the subset of the test suite we care about (for the ruby tests).
