### PR TITLE
Change Fixnum to Numeric to avoid 2.4 deprecated warning

### DIFF
--- a/smells/unclear/complex-assertions/complex-assertions.rb
+++ b/smells/unclear/complex-assertions/complex-assertions.rb
@@ -2,7 +2,7 @@
 
 def increment_age(people)
   people.dup.map { |person|
-    if person.age.kind_of?(Fixnum)
+    if person.age.kind_of?(Numeric)
       person.age += 1
     end
     if person.kids.kind_of?(Array)


### PR DESCRIPTION
Hello

Maybe we should change Fixnum to ~~Integer~~Numeric to avoid warning (on 2.4):
```sh
 🚴  test-smells/ ‹master› » bundle exec rake
Run options: --seed 29801

# Running:

...................../Users/benoit/code/test-smells/smells/unclear/complex-assertions/complex-assertions.rb:5: warning: constant ::Fixnum is deprecated
................................................

Finished in 0.015707s, 4392.9458 runs/s, 5602.5975 assertions/s.
```