### PR TITLE
Change `doesNotRaise` to `doesNotThrow`

### DIFF
--- a/smells/insufficient/invisible-assertions/README.md
+++ b/smells/insufficient/invisible-assertions/README.md
@@ -28,7 +28,7 @@ Davis](https://twitter.com/the_zenspider).
 
 This bit of Ruby implements such an assertion:
 `def assert_nothing_raised; yield; end`, as does this JavaScript:
-`assert.doesNotRaise = f => f()`.
+`assert.doesNotThrow = f => f()`.
 
 ### 2. The case is implicitly covered by another test
 


### PR DESCRIPTION
`assert` does not have a `doesNotRaise` function. Its actual name is `doesNotThrow`